### PR TITLE
use semver to determine newest

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ var source = {
   devDependencies: {
     a: '1.0',
     b: '2.0',
-    e: '1.0'
+    e: '1.0',
+    f: '1.0'
   }
 };
 
@@ -24,7 +25,8 @@ var ours = {
     a: '1.0',
     // b: '2.0', // user removed dep on 'b'
     c: '3.0', // and added dep on 'c'
-    e: '1.0'
+    e: '1.0',
+    f: '2.0'  // user updated independently to latest
   }
 };
 
@@ -34,7 +36,8 @@ var theirs = {
     a: '1.5', // a was bumped
     b: '2.5', // b was bumped
     d: '1.0', // ember-cli introduced new dep on d
-    // e: '1.0' // e was removed
+    // e: '1.0', // e was removed
+    f: '1.5'  // f was bumped, but `ours` is newer so ignore
   }
 };
 
@@ -49,11 +52,11 @@ console.log(result.devDependencies.remove);
 
 console.log(result.devDependencies.change);
 // [{name: 'a', version: '1.5', fromVersion: '1.0'}]  // need to update a@1.0 to a@1.5
+// dep 'f' is not listed as requiring change because user explicitly updated it past `theirs` version
 
 ```
 
 ## to do
 
- * use semver to determine whether change is upgrade or downgrade
  * documentation
  * create ember addon to consume this output

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,3 +1,4 @@
+var semver = require('semver');
 var DependencySet = require('./dependency-set');
 var Diff = require('./diff');
 var DepDiff = require('./dependency-diff');
@@ -6,6 +7,19 @@ var Merge = function Merge(add, remove, change) {
   this.remove = remove.toArray();
   this.change = change.toArray();
 };
+
+var Range = semver.Range;
+
+function minVersion(range) {
+  var r = new Range(range);
+
+  // "" or "*"
+  if (!r.range) {
+    return '0.0.0';
+  }
+
+  return r.set[0][0].semver.version;
+}
 
 /**
  * Merge 3 dependency sets
@@ -39,7 +53,8 @@ Merge.create = function(options) {
   });
   diff.changed.forEach(function(changedDep) {
     var ourDep = ours.get(changedDep.name);
-    if (ourDep && ourDep.version !== changedDep.version) {
+    if (ourDep && ourDep.version !== changedDep.version &&
+        semver.lt(minVersion(ourDep.version), minVersion(changedDep.version))) {
       change.push(DepDiff.fromDep(changedDep, {fromVersion: ourDep.version}));
     }
   });

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   ],
   "author": "Cory Forsyth <cory.forsyth@gmail.com> (http://coryforsyth.com/)",
   "license": "MIT",
+  "dependencies": {
+    "semver": "^5.4.1"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint-config-google": "^0.4.0",
-    "mocha": "^2.4.5",
-    "semver": "^5.1.0"
+    "mocha": "^2.4.5"
   }
 }

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -196,16 +196,12 @@ describe('Merge', function() {
       }
     };
 
-    it('marked for change', function() {
+    it('not marked for change', function() {
       var merge = createMerge(json);
 
       expect(merge.remove.length).to.equal(0);
       expect(merge.add.length).to.equal(0);
-      expect(merge.change.length).to.equal(1);
-
-      var dep = merge.change[0];
-      expect(dep.version).to.equal('1.1');
-      expect(dep.fromVersion).to.equal('1.2');
+      expect(merge.change.length).to.equal(0);
     });
   });
 
@@ -250,16 +246,12 @@ describe('Merge', function() {
       }
     };
 
-    it('marked for change', function() {
+    it('not marked for change', function() {
       var merge = createMerge(json);
 
       expect(merge.remove.length).to.equal(0);
       expect(merge.add.length).to.equal(0);
-      expect(merge.change.length).to.equal(1);
-
-      var dep = merge.change[0];
-      expect(dep.version).to.equal('0.9');
-      expect(dep.fromVersion).to.equal('1.1');
+      expect(merge.change.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
You might want to wait for the result of https://github.com/npm/node-semver/pull/208 as that would be better. Or we can incrementally update.

This fixes the obvious "upstream upgraded, but mine is newer so don't change", but what about, "I downgraded because theres a bug (0.9), but upstream upgraded (1.0 -> 1.1), which wins?"