### PR TITLE
remove bundledDependencies from processing

### DIFF
--- a/lib/dependency-keys.js
+++ b/lib/dependency-keys.js
@@ -2,6 +2,5 @@ module.exports = [
   'dependencies',
   'devDependencies',
   'peerDependencies',
-  'bundledDependencies',
   'optionalDependencies'
 ];

--- a/tests/package-descriptor.js
+++ b/tests/package-descriptor.js
@@ -20,9 +20,6 @@ describe('Package Descriptor', function() {
     peerDependencies: {
       'bar': '1.2.3'
     },
-    bundledDependencies: {
-      'baz': '1.2.3'
-    },
     optionalDependencies: {
       'foo': '1.2.3'
     }
@@ -35,7 +32,6 @@ describe('Package Descriptor', function() {
       expect(descriptor.dependencies.length).to.equal(1);
       expect(descriptor.devDependencies.length).to.equal(2);
       expect(descriptor.peerDependencies.length).to.equal(1);
-      expect(descriptor.bundledDependencies.length).to.equal(1);
       expect(descriptor.optionalDependencies.length).to.equal(1);
     });
 

--- a/tests/three-way-merger.js
+++ b/tests/three-way-merger.js
@@ -27,9 +27,6 @@ describe('Three Way Merger', function() {
           },
           peerDependencies: {
             h: '1.0'
-          },
-          bundledDependencies: {
-            i: '1.0'
           }
         },
         ours: {
@@ -44,9 +41,6 @@ describe('Three Way Merger', function() {
             e: '2.5',
             f: '3.0',
             f2: '1.0'
-          },
-          bundledDependencies: {
-            i: '1.0'
           },
           optionalDependencies: {
             g: '1.0'
@@ -82,7 +76,6 @@ describe('Three Way Merger', function() {
       expect(merge.dependencies).to.be.ok;
       expect(merge.devDependencies).to.be.ok;
       expect(merge.peerDependencies).to.be.ok;
-      expect(merge.bundledDependencies).to.be.ok;
       expect(merge.optionalDependencies).to.be.ok;
 
       expect(merge.dependencies.add.length).to.equal(1);
@@ -101,11 +94,6 @@ describe('Three Way Merger', function() {
       expect(merge.peerDependencies.add.length).to.equal(0);
       expect(merge.peerDependencies.remove.length).to.equal(0);
       expect(merge.peerDependencies.change.length).to.equal(0);
-
-      expect(merge.bundledDependencies.add.length).to.equal(0);
-      expect(merge.bundledDependencies.remove.length).to.equal(1);
-      expect(merge.bundledDependencies.remove[0].name).to.equal('i');
-      expect(merge.bundledDependencies.change.length).to.equal(0);
 
       expect(merge.optionalDependencies.add.length).to.equal(0);
       expect(merge.optionalDependencies.remove.length).to.equal(0);


### PR DESCRIPTION
@elwayman02 informed me I made a mistake treating bundledDependencies like the other dependencies. It is in fact an array and not an object with versions.

https://github.com/ember-cli/ember-cli-update/issues/539