### PR TITLE
support simple hint matching

### DIFF
--- a/lib/dependency-diff.js
+++ b/lib/dependency-diff.js
@@ -1,3 +1,24 @@
+var Range = require('semver').Range;
+
+// matches "^1.0.0" but not "^1.0.0 || ^3.0.0" or "1.0"
+function hasSimpleHint(rangeString) {
+  var range = new Range(rangeString);
+  var isSimpleRange = range.set.length === 1 && range.set[0].length === 2;
+  return isSimpleRange && !!getHint(rangeString);
+}
+
+// matches "1.0.0" and "1.0" but not "^1.0.0"
+function hasNoHint(rangeString) {
+  var range = new Range(rangeString);
+  var isPinned = range.set.length === 1 && range.set[0].length === 1;
+  return isPinned || !getHint(rangeString);
+}
+
+function getHint(rangeString) {
+  var matches = rangeString.match(/^ *[\^~]/);
+  return matches && matches[0];
+}
+
 /**
  * A dependency "diff".
  * Has `name` and `version` properties just like a Dependency,
@@ -11,6 +32,17 @@ var DependencyDiff = function DependencyDiff(dependency, options) {
 
   if (options && options.fromVersion) {
     this.fromVersion = options.fromVersion;
+
+    if (dependency.fromVersion && hasSimpleHint(options.fromVersion)) {
+      let ourHint = getHint(options.fromVersion);
+      if (hasNoHint(dependency.fromVersion) && hasNoHint(dependency.version)) {
+        this.version = `${ourHint}${dependency.version}`;
+      }
+      if (hasSimpleHint(dependency.fromVersion) && hasSimpleHint(dependency.version)
+        && getHint(dependency.fromVersion) === getHint(dependency.version)) {
+        this.version = dependency.version.replace(/[\^~]/, ourHint);
+      }
+    }
   }
 };
 

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -263,6 +263,46 @@ describe('Merge', function() {
     });
   });
 
+  describe('present in ours, upgraded in theirs, but keep our hint', function() {
+    var json = {
+      source: {
+        'a': '1',
+        'b': '^1'
+      },
+      ours: {
+        'a': '^1',
+        'b': '~1',
+        'c': '^1'
+      },
+      theirs: {
+        'a': '2',
+        'b': '2',
+        'c': '2'
+      }
+    };
+
+    it('marked for change', function() {
+      var merge = createMerge(json);
+
+      expect(merge.remove.length).to.equal(0);
+      expect(merge.add.length).to.equal(0);
+      expect(merge.change.length).to.equal(3);
+
+      var dep = merge.change[0];
+      expect(dep.name).to.equal('c');
+      expect(dep.version).to.equal('2');
+      expect(dep.fromVersion).to.equal('^1');
+      var dep = merge.change[1];
+      expect(dep.name).to.equal('a');
+      expect(dep.version).to.equal('^2');
+      expect(dep.fromVersion).to.equal('^1');
+      var dep = merge.change[2];
+      expect(dep.name).to.equal('b');
+      expect(dep.version).to.equal('2');
+      expect(dep.fromVersion).to.equal('~1');
+    });
+  });
+
   describe('ours uses git fork, use ours', function() {
     var json = {
       source: {


### PR DESCRIPTION
Scenario is:
Your version is ^1.0.0.
Remote upgraded from 1.0.0 to 1.1.4.

Currently you end up getting pinned: ^1.0.0 => 1.1.4

I propose we attempt to match the range of the source, so ^1.0.0 => ^1.1.4

It is OK if you don't agree this logic belongs here. I can move it to the consumer https://github.com/kellyselden/merge-package.json.